### PR TITLE
DO NOT MERGE - Spike use different loaders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :development do
   else
     gem 'puppet',                            :require => false
   end
+  # TODO Should this be vendored into Editor Services?
+  # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the
+  # Gemfile here for testing and development.
+  gem "puppet-strings", "~> 2.0", :require => false
 
   case RUBY_PLATFORM
   when /darwin/

--- a/lib/puppet-languageserver-sidecar/cache/filesystem.rb
+++ b/lib/puppet-languageserver-sidecar/cache/filesystem.rb
@@ -101,7 +101,11 @@ module PuppetLanguageServerSidecar
       end
 
       def calculate_hash(filepath)
-        Digest::SHA256.hexdigest(read_file(filepath))
+        if PuppetLanguageServerSidecar.featureflag?('pup4api')
+          File.mtime(filepath).iso8601
+        else
+          Digest::SHA256.hexdigest(read_file(filepath))
+        end
       end
     end
   end

--- a/lib/puppet-languageserver-sidecar/cache/filesystem.rb
+++ b/lib/puppet-languageserver-sidecar/cache/filesystem.rb
@@ -13,7 +13,7 @@ module PuppetLanguageServerSidecar
         begin
           Dir.mkdir(@cache_dir) unless Dir.exist?(@cache_dir)
         rescue Errno::ENOENT => e
-          PuppetLanguageServerSidecar.log_message(:error, "[PuppetLanguageServerSidecar::Cache::File] An error occured while creating file cache.  Disabling cache: #{e}")
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetLanguageServerSidecar::Cache::FileSystem] An error occured while creating file cache.  Disabling cache: #{e}")
           @cache_dir = nil
         end
       end
@@ -35,20 +35,20 @@ module PuppetLanguageServerSidecar
 
         # Check that this is from the same language server version
         unless json_obj['sidecar_version'] == PuppetLanguageServerSidecar.version
-          PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::load] Error loading #{absolute_path}: Expected sidecar_version version #{PuppetLanguageServerSidecar.version} but found #{json_obj['sidecar_version']}")
+          PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::Cache::FileSystem.load] Error loading #{absolute_path}: Expected sidecar_version version #{PuppetLanguageServerSidecar.version} but found #{json_obj['sidecar_version']}")
           return nil
         end
         # Check that the source file hash matches
         content_hash = calculate_hash(absolute_path)
         if json_obj['file_hash'] != content_hash
-          PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::load] Error loading #{absolute_path}: Expected file_hash of #{content_hash} but found #{json_obj['file_hash']}")
+          PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::Cache::FileSystem.load] Error loading #{absolute_path}: Expected file_hash of #{content_hash} but found #{json_obj['file_hash']}")
           return nil
         end
-        PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::load] Loading #{absolute_path} from cache")
+        PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::Cache::FileSystem.load] Loading #{absolute_path} from cache")
 
         json_obj['data']
       rescue RuntimeError => detail
-        PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::load] Error loading #{absolute_path}: #{detail}")
+        PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::Cache::FileSystem.load] Error loading #{absolute_path}: #{detail}")
         raise
       end
 
@@ -65,7 +65,16 @@ module PuppetLanguageServerSidecar
         content['path'] = absolute_path
         content['section'] = section
 
+        PuppetLanguageServerSidecar.log_message(:debug, "[PuppetLanguageServerSidecar::Cache::FileSystem.save] Saving #{absolute_path} to cache")
         save_file(cache_file, content.to_json)
+      end
+
+      # WARNING - This method is only intended for testing the cache
+      # and should not be used for normal operations
+      def clear
+        return unless active?
+        PuppetLanguageServerSidecar.log_message(:warn, '[PuppetLanguageServerSidecar::Cache::FileSystem.clear] Filesystem based cache is being cleared')
+        FileUtils.rm(Dir.glob(File.join(cache_dir, '*')), :force => true)
       end
 
       private

--- a/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
@@ -136,6 +136,13 @@ module PuppetLanguageServerSidecar
           obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
           result[:functions] << obj
         end
+        # Enumerate V4 Functions from the monkey patching
+        Puppet::Functions.monkey_function_list
+                         .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
+                         .each do |name, item|
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
+          result[:functions] << obj
+        end
         PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_via_pup4_api] Finished loading #{result[:functions].count} functions")
       end
 

--- a/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
@@ -140,6 +140,9 @@ module PuppetLanguageServerSidecar
         Puppet::Functions.monkey_function_list
                          .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
                          .each do |name, item|
+          file_doc = PuppetLanguageServerSidecar::PuppetStringsHelper.file_documentation(item[:source_location][:source])
+
+          item.populate_documentation!(file_doc.fetch_function(name))
           obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
           result[:functions] << obj
         end

--- a/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_pup4api.rb
@@ -1,0 +1,357 @@
+require 'puppet/indirector/face'
+
+module PuppetLanguageServerSidecar
+  module PuppetHelper
+    SIDECAR_PUPPET_ENVIRONMENT = 'sidecarenvironment'.freeze
+
+    def self.path_has_child?(path, child)
+      # Doesn't matter what the child is, if the path is nil it's true.
+      return true if path.nil?
+      return false if path.length >= child.length
+
+      value = child.slice(0, path.length)
+      return true if value.casecmp(path).zero?
+      false
+    end
+
+    # Resource Face
+    def self.get_puppet_resource(typename, title = nil)
+      result = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      if title.nil?
+        resources = Puppet::Face[:resource, '0.0.1'].search(typename)
+      else
+        resources = Puppet::Face[:resource, '0.0.1'].find("#{typename}/#{title}")
+      end
+      return result if resources.nil?
+      resources = [resources] unless resources.is_a?(Array)
+      prune_resource_parameters(resources).each do |item|
+        obj = PuppetLanguageServer::Sidecar::Protocol::Resource.new
+        obj.manifest = item.to_manifest
+        result << obj
+      end
+      result
+    end
+
+    # Class and Defined Type loading
+    def self.retrieve_classes(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_classes] Starting')
+
+      # TODO: Can probably do this better, but this works.
+      current_env = current_environment
+      module_path_list = current_env
+                         .modules
+                         .select { |mod| Dir.exist?(File.join(mod.path, 'manifests')) }
+                         .map { |mod| mod.path }
+      manifest_path_list = module_path_list.map { |mod_path| File.join(mod_path, 'manifests') }
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Loading classes from #{module_path_list}")
+
+      # Find and parse all manifests in the manifest paths
+      classes = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      manifest_path_list.each do |manifest_path|
+        Dir.glob("#{manifest_path}/**/*.pp").each do |manifest_file|
+          begin
+            if path_has_child?(options[:root_path], manifest_file) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+              classes.concat(load_classes_from_manifest(cache, manifest_file))
+            end
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_classes] Error loading manifest #{manifest_file}: #{e} #{e.backtrace}")
+          end
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Finished loading #{classes.count} classes")
+      classes
+    end
+
+    # Function loading
+    def self.retrieve_functions(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::load_functions] Starting')
+
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/parser/functions')
+      current_env = current_environment
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      # Functions that are already loaded (e.g. system default functions like alert)
+      # should already be populated so insert them into the function results
+      #
+      # Find the unique filename list
+      filenames = []
+      Puppet::Parser::Functions.monkey_function_list.each_value do |data|
+        filenames << data[:source_location][:source] unless data[:source_location].nil? || data[:source_location][:source].nil?
+      end
+      # Now add the functions in each file to the cache
+      filenames.uniq.compact.each do |filename|
+        Puppet::Parser::Functions.monkey_function_list
+                                 .select { |_k, i| filename.casecmp(i[:source_location][:source].to_s).zero? }
+                                 .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
+                                 .each do |name, item|
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
+          funcs << obj
+        end
+      end
+
+      # Now we can load functions from the default locations
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of function #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            funcs.concat(load_function_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_functions] Error loading function #{file}: #{err} #{err.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::load_functions] Finished loading #{funcs.count} functions")
+      funcs
+    end
+
+    def self.retrieve_types(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_types] Starting')
+
+      # From https://github.com/puppetlabs/puppet/blob/ebd96213cab43bb2a8071b7ac0206c3ed0be8e58/lib/puppet/metatype/manager.rb#L182-L189
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/type')
+      current_env = current_environment
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+
+      # This is an expensive call
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of type #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            types.concat(load_type_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_types] Error loading type #{file}: #{err} #{err.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_types] Finished loading #{types.count} type/s")
+
+      types
+    end
+
+    # Private functions
+
+    def self.prune_resource_parameters(resources)
+      # From https://github.com/puppetlabs/puppet/blob/488661d84e54904124514ab9e4500e81b10f84d1/lib/puppet/application/resource.rb#L146-L148
+      if resources.is_a?(Array)
+        resources.map(&:prune_parameters)
+      else
+        resources.prune_parameters
+      end
+    end
+    private_class_method :prune_resource_parameters
+
+    def self.current_environment
+      begin
+        env = Puppet.lookup(:environments).get!(Puppet.settings[:environment])
+        return env unless env.nil?
+      rescue Puppet::Environments::EnvironmentNotFound
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Unable to load environment #{Puppet.settings[:environment]}")
+      rescue StandardError => ex
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Error loading environment #{Puppet.settings[:environment]}: #{ex}")
+      end
+      Puppet.lookup(:current_environment)
+    end
+    private_class_method :current_environment
+
+    def self.load_classes_from_manifest(cache, manifest_file)
+      class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+
+      if cache.active?
+        cached_result = cache.load(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION)
+        unless cached_result.nil?
+          begin
+            class_info.from_json!(cached_result)
+            return class_info
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_classes_from_manifest] Error while deserializing #{manifest_file} from cache: #{e}")
+            class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+          end
+        end
+      end
+
+      file_content = File.open(manifest_file, 'r:UTF-8') { |f| f.read }
+
+      parser = Puppet::Pops::Parser::Parser.new
+      result = nil
+      begin
+        result = parser.parse_string(file_content, '')
+      rescue Puppet::ParseErrorWithIssue => _exception
+        # Any parsing errors means we can't inspect the document
+        return class_info
+      end
+
+      # Enumerate the entire AST looking for classes and defined types
+      # TODO: Need to learn how to read the help/docs for hover support
+      if result.model.respond_to? :eAllContents
+        # Puppet 4 AST
+        result.model.eAllContents.select do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = result.locator.line_for_offset(item.offset) - 1
+          puppet_class['char']       = result.locator.offset_on_line(item.offset)
+
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, result.locator)
+          class_info << obj
+        end
+      else
+        result.model._pcore_all_contents([]) do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = item.line
+          puppet_class['char']       = item.pos
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, item.locator)
+          class_info << obj
+        end
+      end
+      cache.save(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION, class_info.to_json) if cache.active?
+
+      class_info
+    end
+    private_class_method :load_classes_from_manifest
+
+    def self.load_function_file(cache, name, absolute_name, autoloader, env)
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION)
+        unless cached_result.nil?
+          begin
+            funcs.from_json!(cached_result)
+            return funcs
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_function_file] function #{absolute_name} did not load")
+        end
+      end
+
+      # Find the functions that were loaded based on source file name (case insensitive)
+      Puppet::Parser::Functions.monkey_function_list
+                               .select { |_k, i| absolute_name.casecmp(i[:source_location][:source].to_s).zero? }
+                               .each do |func_name, item|
+        obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(func_name, item)
+        obj.calling_source = absolute_name
+        funcs << obj
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] file #{absolute_name} did load any functions") if funcs.count.zero?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION, funcs.to_json) if cache.active?
+
+      funcs
+    end
+    private_class_method :load_function_file
+
+    def self.load_type_file(cache, name, absolute_name, autoloader, env)
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION)
+        unless cached_result.nil?
+          begin
+            types.from_json!(cached_result)
+            return types
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            types = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      # Get the list of currently loaded types
+      loaded_types = []
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype { |item| loaded_types << item.name }
+      rescue NoMethodError => detail
+        # Detect PUP-8301
+        if detail.respond_to?(:receiver)
+          raise unless detail.name == :each && detail.receiver.nil?
+        else
+          raise unless detail.name == :each && detail.message =~ /nil:NilClass/
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_type_file] type #{absolute_name} did not load")
+        end
+      end
+
+      # Find the types that were loaded
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype do |item|
+          next if loaded_types.include?(item.name)
+          # Ignore the internal only Puppet Types
+          next if item.name == :component || item.name == :whit
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetType.from_puppet(item.name, item)
+          # TODO: Need to use calling_source in the cache backing store
+          # Perhaps I should be incrementally adding items to the cache instead of batch mode?
+          obj.calling_source = absolute_name
+          types << obj
+        end
+      rescue NoMethodError => detail
+        # Detect PUP-8301
+        if detail.respond_to?(:receiver)
+          raise unless detail.name == :each && detail.receiver.nil?
+        else
+          raise unless detail.name == :each && detail.message =~ /nil:NilClass/
+        end
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] type #{absolute_name} did not load any types") if types.empty?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION, types.to_json) if cache.active?
+
+      types
+    end
+    private_class_method :load_type_file
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
@@ -55,13 +55,23 @@ class Puppet::Node::Environment # rubocop:disable Style/ClassAndModuleChildren
     begin
       metadata = workspace_load_json(File.read(md_file, :encoding => 'utf-8'))
       return nil if metadata['name'].nil?
-      # TODO : Need to rip out the module name
+      # Extract the actual module name
+      if Puppet::Module.is_module_directory_name?(metadata['name'])
+        module_name = metadata['name']
+      elsif Puppet::Module.is_module_namespaced_name?(metadata['name'])
+        # Based on regex at https://github.com/puppetlabs/puppet/blob/f5ca8c05174c944f783cfd0b18582e2160b77d0e/lib/puppet/module.rb#L54
+        result = /^[a-zA-Z0-9]+[-]([a-z][a-z0-9_]*)$/.match(metadata['name'])
+        module_name = result[1]
+      else
+        # TODO: This is an invalid puppet module name in the metadata.json.  Should we log an error/warning?
+        return nil
+      end
 
       # The Puppet::Module initializer was changed in
       # https://github.com/puppetlabs/puppet/commit/935c0311dbaf1df03937822525c36b26de5390ef
       # We need to switch the creation based on whether the modules_strict_semver? method is available
-      return Puppet::Module.new(metadata['name'], path, self, modules_strict_semver?) if respond_to?('modules_strict_semver?')
-      return Puppet::Module.new(metadata['name'], path, self)
+      return Puppet::Module.new(module_name, path, self, modules_strict_semver?) if respond_to?('modules_strict_semver?')
+      return Puppet::Module.new(module_name, path, self)
     rescue StandardError
       return nil
     end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
@@ -1,0 +1,87 @@
+# Monkey Patch 3.x functions so where know where they were loaded from
+require 'puppet/parser/functions'
+module Puppet
+  module Parser
+    module Functions
+      class << self
+        alias_method :original_newfunction, :newfunction
+        def newfunction(name, options = {}, &block)
+          # See if we've hooked elsewhere. This can happen while in debuggers (pry). If we're not in the previous caller
+          # stack then just use the last caller
+          monkey_index = Kernel.caller_locations.find_index { |loc| loc.path.match(/puppet_monkey_patches\.rb/) }
+          monkey_index = -1 if monkey_index.nil?
+          caller = Kernel.caller_locations[monkey_index + 1]
+          # Call the original new function method
+          result = original_newfunction(name, options, &block)
+          # Append the caller information
+          result[:source_location] = {
+            :source => caller.absolute_path,
+            :line   => caller.lineno - 1 # Convert to a zero based line number system
+          }
+          monkey_append_function_info(name, result)
+
+          result
+        end
+
+        def monkey_clear_function_info
+          @monkey_function_list = {}
+        end
+
+        def monkey_append_function_info(name, value)
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list[name] = {
+            :arity           => value[:arity],
+            :name            => value[:name],
+            :type            => value[:type],
+            :doc             => value[:doc],
+            :source_location => value[:source_location]
+          }
+        end
+
+        def monkey_function_list
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list.clone
+        end
+      end
+    end
+  end
+end
+
+# Add an additional method on Puppet Types to store their source location
+require 'puppet/type'
+module Puppet
+  class Type
+    class << self
+      attr_accessor :_source_location
+    end
+  end
+end
+
+# Monkey Patch type loading so we can inject the source location information
+require 'puppet/metatype/manager'
+module Puppet
+  module MetaType
+    module Manager
+      alias_method :original_newtype, :newtype
+      def newtype(name, options = {}, &block)
+        result = original_newtype(name, options, &block)
+
+        if block_given? && !block.source_location.nil?
+          result._source_location = {
+            :source => block.source_location[0],
+            :line   => block.source_location[1] - 1 # Convert to a zero based line number system
+          }
+        end
+        result
+      end
+    end
+  end
+end
+
+# MUST BE LAST!!!!!!
+# Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
+Puppet::Util::Log.newdesttype :null_logger do
+  def handle(msg)
+    PuppetLanguageServerSidecar.log_message(:debug, "[PUPPET LOG] [#{msg.level}] #{msg.message}")
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
@@ -78,6 +78,92 @@ module Puppet
   end
 end
 
+# The Ruby Legacy Function Instantiator doesn't have any error catching upon loading and would normally cause the entire puppet
+# run to fail. However as we're a bit special, we can wrap the loader in rescue block and just continue on
+require 'puppet/pops/loader/ruby_legacy_function_instantiator'
+module Puppet
+  module Pops
+    module Loader
+      class RubyLegacyFunctionInstantiator
+        class << self
+          alias_method :original_create, :create
+        end
+
+        def self.create(loader, typed_name, source_ref, ruby_code_string)
+          original_create(loader, typed_name, source_ref, ruby_code_string)
+        rescue LoadError, StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[MonkeyPatch::Puppet::Pops::Loader::RubyLegacyFunctionInstantiator] Error loading legacy function #{typed_name.name}: #{err} #{err.backtrace}")
+        end
+      end
+    end
+  end
+end
+
+# The Ruby Function Instantiator doesn't have any error catching upon loading and would normally cause the entire puppet
+# run to fail. However as we're a bit special, we can wrap the loader in rescue block and just continue on
+require 'puppet/pops/loader/ruby_function_instantiator'
+module Puppet
+  module Pops
+    module Loader
+      class RubyFunctionInstantiator
+        class << self
+          alias_method :original_create, :create
+        end
+
+        def self.create(loader, typed_name, source_ref, ruby_code_string)
+          original_create(loader, typed_name, source_ref, ruby_code_string)
+        rescue LoadError, StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[MonkeyPatch::Puppet::Pops::Loader::RubyLegacyFunctionInstantiator] Error loading function #{typed_name.name}: #{err} #{err.backtrace}")
+        end
+      end
+    end
+  end
+end
+
+if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+  # Due to PUP-9509, need to monkey patch the cache loader
+  # This need to be guarded on Puppet 6.0.0+
+  require 'puppet/pops/loader/module_loaders'
+  module Puppet
+    module Pops
+      module Loader
+        module ModuleLoaders
+          def self.cached_loader_from(parent_loader, loaders)
+            LibRootedFileBased.new(parent_loader,
+                                   loaders,
+                                   NAMESPACE_WILDCARD,
+                                   Puppet[:libdir],
+                                   'cached_puppet_lib',
+                                   %i[func_4x func_3x datatype])
+          end
+        end
+      end
+    end
+  end
+end
+
+# DEBUG It's hard to remember what locations are searched. This simple monkey patch
+# DEBUG will output what paths are being searched by what SmartPaths
+# module Puppet::Pops
+#   module Loader
+#     module ModuleLoaders
+#       class AbstractPathBasedModuleLoader
+#         alias_method :original_discover, :discover
+
+#         def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+#           PuppetLanguageServerSidecar.log_message(:debug, "--- AbstractPathBasedModuleLoader::discover name=#{self.loader_name}")
+#           if name_authority == Pcore::RUNTIME_NAME_AUTHORITY
+#             smart_paths.effective_paths(type).each do |sp|
+#               PuppetLanguageServerSidecar.log_message(:debug, "Using SmartPath [#{sp.class.to_s}]Root=#{sp.root_path}")
+#             end
+#           end
+#           original_discover(type, error_collector, name_authority, &block)
+#         end
+#       end
+#     end
+#   end
+# end
+
 # MUST BE LAST!!!!!!
 # Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
 Puppet::Util::Log.newdesttype :null_logger do

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -1,0 +1,120 @@
+module PuppetLanguageServerSidecar
+  module PuppetStringsHelper
+    # Returns a FileDocumentation object for a given path
+    #
+    # @param [String] path The absolute path to the file that will be documented
+    # @return [FileDocumentation, nil] Returns the documentation for the path, or nil if it cannot be extracted
+    def self.file_documentation(path)
+      return nil unless require_puppet_strings
+      @helper_cache = FileDocumentationCache.new if @helper_cache.nil?
+      return @helper_cache.document(path) if @helper_cache.path_exists?(path)
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetStringsHelper::file_documentation] Fetching documentation for #{path}")
+
+      setup_yard!
+
+      # For now, assume a single file path
+      search_patterns = [path]
+
+      # Format the arguments to YARD
+      args = ['doc']
+      args << '--no-output'
+      args << '--quiet'
+      args << '--no-stats'
+      args << '--no-progress'
+      args << '--no-save'
+      args << '--api public'
+      args << '--api private'
+      args << '--no-api'
+      args += search_patterns
+
+      # Run YARD
+      ::YARD::CLI::Yardoc.run(*args)
+
+      # Populate the documentation cache from the YARD information
+      @helper_cache.populate_from_yard_registry!
+
+      # Return the documentation details
+      @helper_cache.document(path)
+    end
+
+    def self.require_puppet_strings
+      return @puppet_strings_loaded unless @puppet_strings_loaded.nil?
+      begin
+        require 'puppet-strings'
+        require 'puppet-strings/yard'
+        require 'puppet-strings/json'
+        @puppet_strings_loaded = true
+      rescue LoadError => e
+        PuppetLanguageServerSidecar.log_message(:error, "[PuppetStringsHelper::require_puppet_strings] Unable to load puppet-strings gem: #{e}")
+        @puppet_strings_loaded = false
+      end
+      @puppet_strings_loaded
+    end
+    private_class_method :require_puppet_strings
+
+    def self.setup_yard!
+      unless @yard_setup # rubocop:disable Style/GuardClause
+        ::PuppetStrings::Yard.setup!
+        @yard_setup = true
+      end
+    end
+    private_class_method :setup_yard!
+  end
+
+  class FileDocumentationCache
+    def initialize
+      # Hash of <[String] path, FileDocumentation> objects
+      @cache = {}
+    end
+
+    def path_exists?(path)
+      @cache.key?(path)
+    end
+
+    def document(path)
+      @cache[path]
+    end
+
+    def populate_from_yard_registry!
+      # Extract all of the information
+      # Ref - https://github.com/puppetlabs/puppet-strings/blob/87a8e10f45bfeb7b6b8e766324bfb126de59f791/lib/puppet-strings/json.rb#L10-L16
+      populate_functions_from_yard_registry!
+    end
+
+    private
+
+    def populate_functions_from_yard_registry!
+      ::YARD::Registry.all(:puppet_function).map(&:to_hash).each do |item|
+        source_path = item[:file]
+        func_name = item[:name].to_s
+        @cache[source_path] = FileDocumentation.new(source_path) if @cache[source_path].nil?
+
+        func_doc = FunctionDocumentation.new
+        func_doc.doc = item[:docstring][:text]
+
+        @cache[source_path].functions[func_name] = func_doc
+      end
+    end
+  end
+
+  class FileDocumentation
+    # The path to file that has been documented
+    attr_reader :path
+
+    # Hash of <[String]Name, FunctionDocumentation> objects
+    attr_accessor :functions
+
+    def initialize(path)
+      @path = path
+      @functions = {}
+    end
+
+    def fetch_function(func_name)
+      @functions[func_name]
+    end
+  end
+
+  class FunctionDocumentation
+    attr_accessor :doc
+  end
+end

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -47,6 +47,15 @@ module PuppetLanguageServerSidecar
         obj.type  = item[:type]
         obj
       end
+
+      # Populates a Puppet Function protocol object from a FunctionDocumentation object
+      #
+      # @param [PuppetLanguageServerSidecar::PuppetStringsHelper::FunctionDocumentation] func_doc Documentation object used to populate this object
+      # @return [void]
+      def populate_documentation!(func_doc)
+        return if func_doc.nil?
+        @doc = func_doc.doc
+      end
     end
 
     class PuppetType < PuppetLanguageServer::Sidecar::Protocol::PuppetType

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -34,9 +34,18 @@ module PuppetLanguageServerSidecar
       end
     end
 
+    class PuppetFunctionList < PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList
+      def child_type
+        PuppetLanguageServerSidecar::Protocol::PuppetFunction
+      end
+    end
+
     class PuppetFunction < PuppetLanguageServer::Sidecar::Protocol::PuppetFunction
+      attr_accessor :was_cached    # Whether this function's metadata was loaded from the cache
+      attr_accessor :was_preloaded # Whether this function's was pre-loaded by puppet at startup, which avoids our caching layer
+
       def self.from_puppet(name, item)
-        obj = PuppetLanguageServer::Sidecar::Protocol::PuppetFunction.new
+        obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.new
         obj.key            = name
         obj.source         = item[:source_location][:source]
         obj.calling_source = obj.source
@@ -45,6 +54,8 @@ module PuppetLanguageServerSidecar
         obj.doc   = item[:doc]
         obj.arity = item[:arity]
         obj.type  = item[:type]
+        obj.was_cached = false
+        obj.was_preloaded = false
         obj
       end
 

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -21,6 +21,18 @@ ensure
 end
 
 module PuppetLanguageServerSidecar
+  attr_reader :sidecar_cache
+
+  def self.cache
+    @sidecar_cache = PuppetLanguageServerSidecar::Cache::Null.new if @sidecar_cache.nil?
+    @sidecar_cache
+  end
+
+  def self.cache=(value)
+    @sidecar_cache = value
+  end
+  private_class_method :cache=
+
   def self.version
     PuppetEditorServices.version
   end
@@ -257,11 +269,11 @@ module PuppetLanguageServerSidecar
       PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(cache)
 
     when 'default_functions'
-      cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+      self.cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
       if use_pup4api
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_pup4_api(cache, :object_types => [:function])[:functions]
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_pup4_api(:object_types => [:function])[:functions]
       else
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(cache)
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(self.cache)
       end
 
     when 'default_types'
@@ -300,14 +312,13 @@ module PuppetLanguageServerSidecar
                                                                  :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
 
     when 'workspace_functions'
-      null_cache = PuppetLanguageServerSidecar::Cache::Null.new
+      self.cache = PuppetLanguageServerSidecar::Cache::Null.new
       return nil unless inject_workspace_as_module || inject_workspace_as_environment
       if use_pup4api
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_pup4_api(null_cache,
-                                                                        :root_path    => PuppetLanguageServerSidecar::Workspace.root_path,
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_pup4_api(:root_path    => PuppetLanguageServerSidecar::Workspace.root_path,
                                                                         :object_types => [:function])[:functions]
       else
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(null_cache,
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(self.cache,
                                                                      :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
       end
 

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -77,6 +77,7 @@ module PuppetLanguageServerSidecar
     if featureflag?('pup4api')
       require_list << 'puppet_helper_pup4api'
       require_list << 'puppet_monkey_patches_pup4api'
+      require_list << 'puppet_strings_helper'
     else
       require_list << 'puppet_helper'
       require_list << 'puppet_monkey_patches'

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded
+Puppet::Functions.create_function(:default_pup4_function) do
+  # @return [Array<String>]
+  def default_pup4_function
+    'default_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the environment namespace
+Puppet::Functions.create_function(:'environment::default_env_pup4_function') do
+  # @return [Array<String>]
+  def default_env_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the module called 'modname' namespace
+Puppet::Functions.create_function(:'modname::default_mod_pup4_function') do
+  # @return [Array<String>]
+  def default_mod_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the environment namespace
+Puppet::Functions.create_function(:'badname::pup4_function') do
+  # @return [Array<String>]
+  def pup4_function
+    'pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'profile::pup4_envprofile_function') do
+  # @return [Array<String>]
+  def pup4_envprofile_function
+    'pup4_envprofile_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:pup4_env_badfile) do
+  # @return [Array<String>]
+  def pup4_env_badfile
+    'pup4_env_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:pup4_env_badfunction) do
+  # @return [Array<String>]
+  def pup4_env_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'pup4_env_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# ??? This should be loaded as global namespace function
+Puppet::Functions.create_function(:pup4_env_function) do
+  # @return [Array<String>]
+  def pup4_env_function
+    'pup4_env_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the module namespace
+Puppet::Functions.create_function(:'badname::fixture_pup4_badname_function') do
+  # @return [Array<String>]
+  def fixture_pup4_badname_function
+    'fixture_pup4_badname_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:fixture_pup4_badfile) do
+  # @return [Array<String>]
+  def fixture_pup4_badfile
+    'fixture_pup4_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:fixture_pup4_badfunction) do
+  # @return [Array<String>]
+  def fixture_pup4_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'fixture_pup4_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded as global namespace function
+Puppet::Functions.create_function(:fixture_pup4_function) do
+  # @return [Array<String>]
+  def fixture_pup4_function
+    'fixture_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'valid::fixture_pup4_mod_function') do
+  # @return [Array<String>]
+  def fixture_pup4_mod_function
+    'fixture_pup4_mod_function result'
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
@@ -2,9 +2,12 @@ require 'spec_helper'
 require 'open3'
 require 'tempfile'
 
-describe 'PuppetLanguageServerSidecar' do
+describe 'PuppetLanguageServerSidecar with Feature Flag pup4api' do
   def run_sidecar(cmd_options)
     cmd_options << '--no-cache'
+
+    # Append the feature flag
+    cmd_options << '--feature-flag=pup4api'
 
     # Append the puppet test-fixtures
     cmd_options << '--puppet-settings'

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
@@ -178,7 +178,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Ve
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :fixture_pup4_function)
-        expect(func.doc).to be_nil  # Currently we can't get the documentation for v4 functions
+        expect(func.doc).to match(/Example function using the Puppet 4 API in a module/)
         expect(func.source).to match(/valid_module_workspace/)
       end
     end
@@ -279,7 +279,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Ve
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :pup4_env_function)
-        expect(func.doc).to be_nil  # Currently we can't get the documentation for v4 functions
+        expect(func.doc).to match(/Example function using the Puppet 4 API in a module/)
         expect(func.source).to match(/valid_environment_workspace/)
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
@@ -4,8 +4,6 @@ require 'tempfile'
 
 describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0') do
   def run_sidecar(cmd_options)
-    cmd_options << '--no-cache'
-
     # Append the feature flag
     cmd_options << '--feature-flag=pup4api'
 
@@ -48,6 +46,37 @@ describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Ve
     end
   end
 
+  before(:each) do
+    # Purge the File Cache
+    cache = PuppetLanguageServerSidecar::Cache::FileSystem.new
+    cache.clear
+  end
+
+  after(:all) do
+    # Purge the File Cache
+    cache = PuppetLanguageServerSidecar::Cache::FileSystem.new
+    cache.clear
+  end
+
+  def expect_empty_cache
+    cache = PuppetLanguageServerSidecar::Cache::FileSystem.new
+    expect(Dir.exists?(cache.cache_dir)).to eq(true), "Expected the cache directory #{cache.cache_dir} to exist"
+    expect(Dir.glob(File.join(cache.cache_dir,'*')).count).to eq(0), "Expected the cache directory #{cache.cache_dir} to be empty"
+  end
+
+  def expect_populated_cache
+    cache = PuppetLanguageServerSidecar::Cache::FileSystem.new
+    expect(Dir.glob(File.join(cache.cache_dir,'*')).count).to be > 0, "Expected the cache directory #{cache.cache_dir} to be populated"
+  end
+
+  def expect_same_array_content(a, b)
+    expect(a.count).to eq(b.count), "Expected array with #{b.count} items to have #{a.count} items"
+
+    a.each_with_index do |item, index|
+      expect(item.to_json).to eq(b[index].to_json), "Expected item at index #{index} to have content #{item.to_json} but got #{b[index].to_json}"
+    end
+  end
+
   describe 'when running default_classes action' do
     let (:cmd_options) { ['--action', 'default_classes'] }
 
@@ -68,7 +97,9 @@ describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Ve
   describe 'when running default_functions action' do
     let (:cmd_options) { ['--action', 'default_functions'] }
 
-    it 'should return a deserializable function list with default functions' do
+    it 'should return a cachable deserializable function list with default functions' do
+      expect_empty_cache
+
       result = run_sidecar(cmd_options)
       deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
       expect { deserial.from_json!(result) }.to_not raise_error
@@ -87,6 +118,16 @@ describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => Gem::Ve
       expect(deserial).to contain_child_with_key(:'environment::default_env_pup4_function')
       # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/modname (module namespaced function)
       expect(deserial).to contain_child_with_key(:'modname::default_mod_pup4_function')
+
+      # Now run using cached information
+      expect_populated_cache
+
+      result2 = run_sidecar(cmd_options)
+      deserial2 = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
+      expect { deserial2.from_json!(result2) }.to_not raise_error
+
+      # The second result should be the same as the first
+      expect_same_array_content(deserial, deserial2)
     end
   end
 


### PR DESCRIPTION
### Phase 1 emulate Puppet 3 functions
- [x] Loads Puppet 4 functions and impersonates Puppet 3 API surface
  - [x] global in a module (tests)
  - [x] namespaced in a module (tests)
  - [x] environment namespace in a module (tests)
- [x] Loads documentation for functions
- [x] Uses caching to speed up lookups

### Phase 2 extend to puppet 4 functions
- [ ] Loads parameter information for functions
- [ ] Loads function signatures for functions